### PR TITLE
Issue 11 speed optimization for io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 This library provides gpio access via the standard linux [sysfs interface](https://www.kernel.org/doc/Documentation/gpio/sysfs.txt)
 
-It is intended to mimick [RPIO](http://pythonhosted.org/RPIO/) as much as possible 
-for all features, while also supporting additional (and better named) functionality 
+It is intended to mimick [RPIO](http://pythonhosted.org/RPIO/) as much as possible
+for all features, while also supporting additional (and better named) functionality
 to the same methods.
 
 
 ## Supported Features
+- log level: set log level to DEBUG to see debug messages
 - get pin values with `read(pin)` or `input(pin)`
 - set pin values with `set(pin, value)` or `output(pin, value)`
 - get the pin mode with `mode(pin)`

--- a/gpio.py
+++ b/gpio.py
@@ -47,7 +47,7 @@ _open = dict()
 FMODE = 'w+'
 
 IN, OUT = 'in', 'out'
-LOW, HIGH = 'low', 'high'
+LOW, HIGH = 0, 1
 
 
 def _write(f, v):

--- a/gpio.py
+++ b/gpio.py
@@ -176,13 +176,11 @@ def set(pin, value):
     _write(f, value)
 
 
-@_verify
 def input(pin):
     '''read the pin. Same as read'''
     return read(pin)
 
 
-@_verify
 def output(pin, value):
     '''set the pin. Same as set'''
     return set(pin, value)

--- a/gpio.py
+++ b/gpio.py
@@ -9,7 +9,7 @@ import pdb
 
 import logging
 # logging.basicConfig(level=logging.ERROR)
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.CRITICAL)
 log = logging.getLogger(__name__)
 
 
@@ -168,9 +168,6 @@ def read(pin):
 @_verify
 def set(pin, value):
     '''set the pin value to 0 or 1'''
-    if value is LOW:
-        value = 0
-    value = int(bool(value))
     log.debug("Write {0}: {1}".format(pin, value))
     f = _open[pin].value
     _write(f, value)


### PR DESCRIPTION
1. **Removed redundant _verify decorators:**
I've removed the _verify decorator from input and output methods

2. The _verify decorators seem to be doing quite a bit. Replacing the decorators with actual lines of code make for code repetition so I've left it as is.

3. Changed LOW, HIGH = 'low', 'high':
Changed to LOW, HIGH = 0, 1, reducing check overhead in set method

4. Logging overheads:
Doing a check before every log statement would be an additional overhead. In order to avoid it, I've set the preconfigured log level to CRITICAL and included a statement in the documentation that directs users to reset the log levels to debug if they wish to see the debug log messages. This way, we avoid checking log level before each log entry.