### PR TITLE
Fix overwriting of logging config

### DIFF
--- a/gpio.py
+++ b/gpio.py
@@ -5,8 +5,6 @@ import threading
 import os
 
 import logging
-# logging.basicConfig(level=logging.ERROR)
-logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Please don't overwrite the basic logging config in a python module, this breaks peoples logging config if one imports gpio :sweat_smile: 