### PR TITLE
14 25 sysfs permissions

### DIFF
--- a/gpio/__init__.py
+++ b/gpio/__init__.py
@@ -2,6 +2,7 @@
 __version__ = '1.0.0'
 
 from threading import Lock
+from time import sleep
 try:
     from collections.abc import Iterable
 except ImportError:
@@ -51,6 +52,8 @@ class GPIOPin(object):
                 with open(GPIO_EXPORT, FMODE_SYS_WO) as f:
                     f.write(str(self.pin))
                     f.flush()
+            # give the kernel a moment to build out the requested sysfs tree
+            sleep(.1)
 
         # Using unbuffered binary IO is ~ 3x faster than text
         self.value = open(os.path.join(self.root, 'value'), FMODE_BIN_RW, buffering=0)

--- a/gpio/__init__.py
+++ b/gpio/__init__.py
@@ -17,8 +17,8 @@ _open_pins = {}
 GPIO_ROOT = '/sys/class/gpio'
 GPIO_EXPORT = os.path.join(GPIO_ROOT, 'export')
 GPIO_UNEXPORT = os.path.join(GPIO_ROOT, 'unexport')
-FMODE_SYS_WO = 'w'   # /sys/class/gpio/export is not readable, even by root
-FMODE_SYS_RW = 'w+'  # w+ overwrites and truncates existing files
+FMODE_STR_WO = 'w'   # /sys/class/gpio/export is not readable, even by root
+FMODE_STR_RW = 'w+'  # w+ overwrites and truncates existing files
 FMODE_BIN_RW = 'wb+' # Using unbuffered binary IO is ~ 3x faster than text
 IN, OUT = 'in', 'out'
 LOW, HIGH = 0, 1
@@ -49,7 +49,7 @@ class GPIOPin(object):
 
         if not os.path.exists(self.root):
             with _export_lock:
-                with open(GPIO_EXPORT, FMODE_SYS_WO) as f:
+                with open(GPIO_EXPORT, FMODE_STR_WO) as f:
                     f.write(str(self.pin))
                     f.flush()
             gpio_gid = os.stat(GPIO_ROOT).st_gid
@@ -109,7 +109,7 @@ class GPIOPin(object):
         Returns:
             str: "in" or "out"
         '''
-        with open(os.path.join(self.root, 'direction'), FMODE_SYS_RW) as f:
+        with open(os.path.join(self.root, 'direction'), FMODE_STR_RW) as f:
             return f.read().strip()
 
     def set_direction(self, mode):
@@ -121,7 +121,7 @@ class GPIOPin(object):
         if mode not in (IN, OUT, LOW, HIGH):
             raise ValueError("Unsupported pin mode {}".format(mode))
 
-        with open(os.path.join(self.root, 'direction'), FMODE_SYS_RW) as f:
+        with open(os.path.join(self.root, 'direction'), FMODE_STR_RW) as f:
             f.write(str(mode))
             f.flush()
 
@@ -134,7 +134,7 @@ class GPIOPin(object):
         if not isinstance(active_low, bool):
             raise ValueError("active_low must be True or False")
 
-        with open(os.path.join(self.root, 'active_low'), FMODE_SYS_RW) as f:
+        with open(os.path.join(self.root, 'active_low'), FMODE_STR_RW) as f:
             f.write('1' if active_low else '0')
             f.flush()
 
@@ -177,7 +177,7 @@ class GPIOPin(object):
 
         if os.path.exists(self.root):
             with _export_lock:
-                with open(GPIO_UNEXPORT, FMODE_SYS_WO) as f:
+                with open(GPIO_UNEXPORT, FMODE_STR_WO) as f:
                     f.write(str(self.pin))
                     f.flush()
 

--- a/gpio/__init__.py
+++ b/gpio/__init__.py
@@ -16,7 +16,9 @@ _open_pins = {}
 GPIO_ROOT = '/sys/class/gpio'
 GPIO_EXPORT = os.path.join(GPIO_ROOT, 'export')
 GPIO_UNEXPORT = os.path.join(GPIO_ROOT, 'unexport')
-FMODE = 'w+'  # w+ overwrites and truncates existing files
+FMODE_SYS_WO = 'w'   # /sys/class/gpio/export is not readable, even by root
+FMODE_SYS_RW = 'w+'  # w+ overwrites and truncates existing files
+FMODE_BIN_RW = 'wb+' # Using unbuffered binary IO is ~ 3x faster than text
 IN, OUT = 'in', 'out'
 LOW, HIGH = 0, 1
 
@@ -46,12 +48,12 @@ class GPIOPin(object):
 
         if not os.path.exists(self.root):
             with _export_lock:
-                with open(GPIO_EXPORT, FMODE) as f:
+                with open(GPIO_EXPORT, FMODE_SYS_WO) as f:
                     f.write(str(self.pin))
                     f.flush()
 
         # Using unbuffered binary IO is ~ 3x faster than text
-        self.value = open(os.path.join(self.root, 'value'), 'wb+', buffering=0)
+        self.value = open(os.path.join(self.root, 'value'), FMODE_BIN_RW, buffering=0)
 
         # I hate manually calling .setup()!
         self.setup(direction, initial, active_low)
@@ -100,7 +102,7 @@ class GPIOPin(object):
         Returns:
             str: "in" or "out"
         '''
-        with open(os.path.join(self.root, 'direction'), FMODE) as f:
+        with open(os.path.join(self.root, 'direction'), FMODE_SYS_RW) as f:
             return f.read().strip()
 
     def set_direction(self, mode):
@@ -112,7 +114,7 @@ class GPIOPin(object):
         if mode not in (IN, OUT, LOW, HIGH):
             raise ValueError("Unsupported pin mode {}".format(mode))
 
-        with open(os.path.join(self.root, 'direction'), FMODE) as f:
+        with open(os.path.join(self.root, 'direction'), FMODE_SYS_RW) as f:
             f.write(str(mode))
             f.flush()
 
@@ -125,7 +127,7 @@ class GPIOPin(object):
         if not isinstance(active_low, bool):
             raise ValueError("active_low must be True or False")
 
-        with open(os.path.join(self.root, 'active_low'), FMODE) as f:
+        with open(os.path.join(self.root, 'active_low'), FMODE_SYS_RW) as f:
             f.write('1' if active_low else '0')
             f.flush()
 
@@ -168,7 +170,7 @@ class GPIOPin(object):
 
         if os.path.exists(self.root):
             with _export_lock:
-                with open(GPIO_UNEXPORT, FMODE) as f:
+                with open(GPIO_UNEXPORT, FMODE_SYS_WO) as f:
                     f.write(str(self.pin))
                     f.flush()
 


### PR DESCRIPTION
Fixes #14 and #25 by adding file modes which better match sysfs file permissions

Fixes subsequent permission error when export is successful but sysfs tree buildout is not complete before attempting to use the new value FH. Slower systems may need a longer delay. Looping with os.path.exists() would likely be a better fix.