### PR TITLE
Fix CI and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.7, 3.9]
+        python: [2.7,3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py{27,35,37,39},qa
+envlist = py{27,39},qa
 skip_missing_interpreters = True
 
 [testenv]
 commands =
 	python setup.py install
-	coverage run -m py.test -v -r wsx
+	coverage run -m pytest -v -r wsx
 	coverage report
 deps =
 	mock


### PR DESCRIPTION
The CI and testing setup has succumbed to bitrot. It needs fixing.

We should probably also make a decision about Python 2.x.